### PR TITLE
Support both single-column and desktop styles.

### DIFF
--- a/styles/desktop.css
+++ b/styles/desktop.css
@@ -3,50 +3,52 @@
 - Put nav bar on the side
 - Put avatar at top of nav bar
 */
-.drawer.rl-hide {
-    width: 0!important;
-    margin-right: -10px!important;
-}
+@media screen and (min-width: 650px) {
+    .drawer.rl-hide {
+        width: 0!important;
+        margin-right: -10px!important;
+    }
 
-.drawer.rl-hide .search {
-    display: none!important
-}
+    .drawer.rl-hide .search {
+        display: none!important
+    }
 
-.drawer {
-  width: 250px!important;
-  margin-left: 85px!important;
-}
+    .drawer {
+      width: 250px!important;
+      margin-left: 85px!important;
+    }
 
-.drawer__header {
-  flex-direction: column!important;
-  width: 75px!important;
-  padding-top: 55px!important;
-  position: absolute;
-  left: 10px!important;
-  top: 10px!important;
-  z-index: 50!important;
-}
+    .drawer__header {
+      flex-direction: column!important;
+      width: 75px!important;
+      padding-top: 55px!important;
+      position: absolute;
+      left: 10px!important;
+      top: 10px!important;
+      z-index: 50!important;
+    }
 
-.navigation-bar .account__avatar {
-  position: fixed!important;
-  top: 22px!important;
-  left: 28px!important;
-  z-index: 51!important;
-}
+    .navigation-bar .account__avatar {
+      position: fixed!important;
+      top: 22px!important;
+      left: 28px!important;
+      z-index: 51!important;
+    }
 
-.drawer__inner__mastodon { 
-  display: none!important; 
-}
-  .columns-area .column {
-          width: calc(80% / 3) !important;
-  }
+    .drawer__inner__mastodon { 
+      display: none!important; 
+    }
+      .columns-area .column {
+              width: calc(80% / 3) !important;
+      }
 
-.drawer {
-      width: calc(20% - 95px)!important;
-  }
+    .drawer {
+          width: calc(20% - 95px)!important;
+      }
 
-.columns-area>div>.column,
-.columns-area>div>.mastodon-column-container>.column
-{
-  width: 100%;
+    .columns-area>div>.column,
+    .columns-area>div>.mastodon-column-container>.column
+    {
+      width: 100%;
+    }
 }


### PR DESCRIPTION
If you add both the single-column.css and desktop.css styles at the same time in an app like Fluid they conflict and break each other.  Wrapping the desktop.css in a media query to only apply at larger widths resolves the conflicts and allows for a better experience if you resize the window from small to big (or vice versa).